### PR TITLE
alterate all the scope to main

### DIFF
--- a/scripts/online-retail.py
+++ b/scripts/online-retail.py
@@ -14,16 +14,14 @@ schema_online_retail = StructType([
 	StructField('Country', StringType(), True),
 ])
  
-if __name__ == "__main__":
-	sc = SparkContext()
-	spark = (SparkSession.builder.appName("Aceleração PySpark - Capgemini [Online Retail]"))
+sc = SparkContext()
+spark = (SparkSession.builder.appName("Aceleração PySpark - Capgemini [Online Retail]"))
 
-	df = (spark.getOrCreate().read
-		          .format("csv")
-		          .option("header", "true")
-		          .schema(schema_online_retail)
-		          .load("/home/spark/capgemini-aceleracao-pyspark/data/online-retail/online-retail.csv"))
-
+df = (spark.getOrCreate().read
+				.format("csv")
+				.option("header", "true")
+				.schema(schema_online_retail)
+				.load("data/online-retail/online-retail.csv"))
 
 # Tratamento UnitPrice
 


### PR DESCRIPTION
# Escopo de código

Neste commit eu sugeri a remoção do 'if __name__ == "__main__": ',  pelo restante do código com as perguntas e o Schema também estar no main, me fazendo crer que a checagem ali podia ser redundante. Nesse caso, esta sugestão do escopo pode ser útil para manter fora o 'if ... main:' ou para inserir todo o código sob o 'if ... main:' 

- [X] *if __name__ == "__main__":* removido  

# E quanto ao restante do código?

Outras sugestões que não foram alteradas neste commit, mas que podem ser debatidas para outros commits são:

- [ ] Sem identação no início e identado no final. (Código em apenas uma linha nas primeiras questões e dividido em mais de uma nas finais)
- [ ] Tipo das colunas no Schema (que poderia ser importado todos como String para realizar a conversão em seguida) 

*Lembrando que todas as sugestões descritas acima são, acima de tudo, sugestões e nenhuma invalida de qualquer forma o trabalho excelente realizado até o momento.*